### PR TITLE
Update and init only route ops in LS 

### DIFF
--- a/pyvrp/cpp/educate/LocalSearchOperator.h
+++ b/pyvrp/cpp/educate/LocalSearchOperator.h
@@ -5,19 +5,18 @@
 #include "PenaltyManager.h"
 #include "Route.h"
 
-template <typename Arg> class LocalSearchOperator
+template <typename Arg> class LocalSearchOperatorBase
 {
+    // Can only be specialised into either a Node or Route operator; there
+    // are no other types that are expected to work.
+    static_assert(std::is_same<Arg, Node>::value
+                  || std::is_same<Arg, Route>::value);
+
 protected:
     ProblemData const &data;
     PenaltyManager const &penaltyManager;
 
 public:
-    /**
-     * Called once after loading in the individual to improve. This can be used
-     * to e.g. update local operator state.
-     */
-    virtual void init(Individual const &indiv){};
-
     /**
      * Determines the cost delta of applying this operator to the arguments.
      * If the cost delta is negative, this is an improving move.
@@ -37,20 +36,44 @@ public:
      */
     virtual void apply(Arg *U, Arg *V){};
 
+    explicit LocalSearchOperatorBase(ProblemData const &data,
+                                     PenaltyManager const &penaltyManager)
+        : data(data), penaltyManager(penaltyManager)
+    {
+    }
+
+    virtual ~LocalSearchOperatorBase() = default;
+};
+
+template <typename Arg>
+class LocalSearchOperator : public LocalSearchOperatorBase<Arg>
+{
+};
+
+template <>  // specialisation for node operators
+class LocalSearchOperator<Node> : public LocalSearchOperatorBase<Node>
+{
+    using LocalSearchOperatorBase::LocalSearchOperatorBase;
+};
+
+template <>  // specialisation for route operators
+class LocalSearchOperator<Route> : public LocalSearchOperatorBase<Route>
+{
+    using LocalSearchOperatorBase::LocalSearchOperatorBase;
+
+public:
+    /**
+     * Called once after loading in the individual to improve. This can be used
+     * to e.g. update local operator state.
+     */
+    virtual void init(Individual const &indiv){};
+
     /**
      * Called when a route has been changed. Can be used to update caches, but
      * the implementation should be fast: this is called every time something
      * changes!
      */
     virtual void update(Route *U){};
-
-    explicit LocalSearchOperator(ProblemData const &data,
-                                 PenaltyManager const &penaltyManager)
-        : data(data), penaltyManager(penaltyManager)
-    {
-    }
-
-    virtual ~LocalSearchOperator() = default;
 };
 
 #endif  // LOCALSEARCHOPERATOR_H

--- a/pyvrp/cpp/educate/RelocateStar.cpp
+++ b/pyvrp/cpp/educate/RelocateStar.cpp
@@ -1,11 +1,5 @@
 #include "RelocateStar.h"
 
-void RelocateStar::init(Individual const &indiv)
-{
-    LocalSearchOperator<Route>::init(indiv);
-    relocate.init(indiv);
-}
-
 int RelocateStar::evaluate(Route *U, Route *V)
 {
     move = {};

--- a/pyvrp/cpp/educate/RelocateStar.h
+++ b/pyvrp/cpp/educate/RelocateStar.h
@@ -23,8 +23,6 @@ class RelocateStar : public LocalSearchOperator<Route>
     Move move;
 
 public:
-    void init(Individual const &indiv) override;
-
     int evaluate(Route *U, Route *V) override;
 
     void apply(Route *U, Route *V) override;


### PR DESCRIPTION
All operators currently have an `init()` and `update()` method, but that's only used by route operators (=SWAP*). This PR makes that explicit in the types, by moving those methods into the route operator template specialisation.

And while we're at it: the route updates now only happen when route operators are applied. That's OK since `search()` and `intensify()` are completely separate.
