### PR TITLE
Move route sorting inside SREX

### DIFF
--- a/pyvrp/cpp/crossover/selective_route_exchange.cpp
+++ b/pyvrp/cpp/crossover/selective_route_exchange.cpp
@@ -13,9 +13,7 @@ namespace
 {
 double _computeRouteAngleCenter(ProblemData const &data, Route const &route)
 {
-    if (route.empty())
-        return 1.e30;
-
+    // Computes the route angle center. Assumes that the route is non-empty.
     int cumulatedX = 0;
     int cumulatedY = 0;
 
@@ -49,8 +47,9 @@ Routes _getNonEmptyRoutesSortedByAngleCenter(ProblemData const &data,
                 _computeRouteAngleCenter(data, routes[r]), r);
         }
 
-    // Empty routes have a large center angle, and thus always sort at the end
-    std::sort(routePolarAngles.begin(), routePolarAngles.end());
+    // Sort angles of non-empty routes
+    std::sort(routePolarAngles.begin(),
+              routePolarAngles.begin() + numNonEmptyRoutes);
 
     Routes resultRoutes;
     resultRoutes.reserve(numNonEmptyRoutes);

--- a/pyvrp/cpp/crossover/selective_route_exchange.cpp
+++ b/pyvrp/cpp/crossover/selective_route_exchange.cpp
@@ -11,7 +11,7 @@ using Routes = std::vector<Route>;
 
 namespace
 {
-double _computeRouteAngleCenter(ProblemData const &data, Route const &route)
+double routeAngle(ProblemData const &data, Route const &route)
 {
     // Computes the route angle center. Assumes that the route is non-empty.
     int cumulatedX = 0;
@@ -32,31 +32,23 @@ double _computeRouteAngleCenter(ProblemData const &data, Route const &route)
     return std::copysign(1. - dx / (std::fabs(dx) + std::fabs(dy)), dy);
 }
 
-Routes _getNonEmptyRoutesSortedByAngleCenter(ProblemData const &data,
-                                             Routes const routes)
+Routes getNonEmptyRoutesByAscendingAngle(ProblemData const &data, Routes routes)
 {
-    std::vector<std::pair<double, int>> routePolarAngles;
-    routePolarAngles.reserve(data.numVehicles());
+    auto cmp = [&data](Route a, Route b) {
+        return (a.empty() || b.empty())
+                   ? !a.empty() && b.empty()
+                   : routeAngle(data, a) < routeAngle(data, b);
+    };
 
-    size_t numNonEmptyRoutes = 0;
-    for (size_t r = 0; r < data.numVehicles(); r++)
-        if (!routes[r].empty())
-        {
-            numNonEmptyRoutes++;
-            routePolarAngles.emplace_back(
-                _computeRouteAngleCenter(data, routes[r]), r);
-        }
+    std::sort(routes.begin(), routes.end(), cmp);
 
-    // Sort angles of non-empty routes
-    std::sort(routePolarAngles.begin(),
-              routePolarAngles.begin() + numNonEmptyRoutes);
+    size_t empty = 0;
+    for (; empty != routes.size(); ++empty)
+        if (routes[empty].empty())
+            break;
 
-    Routes resultRoutes;
-    resultRoutes.reserve(numNonEmptyRoutes);
-    for (size_t r = 0; r < numNonEmptyRoutes; r++)
-        resultRoutes.emplace_back(routes[routePolarAngles[r].second]);
-
-    return resultRoutes;
+    routes.resize(empty);
+    return routes;
 }
 }  // namespace
 
@@ -67,15 +59,30 @@ Individual selectiveRouteExchange(
     std::pair<size_t, size_t> const startIndices,
     size_t const numMovedRoutes)
 {
+    // We create two candidate offsprings, both based on parent A:
+    // Let A and B denote the set of customers selected from parents A and B
+    // Ac and Bc denote the complements: the customers not selected
+    // Let v denote union and ^ intersection
+    // Parent A: A v Ac
+    // Parent B: B v Bc
+
+    // Offspring 1:
+    // B and Ac\B, remainder A\B unplanned
+    // (note B v (Ac\B) v (A\B) = B v ((Ac v A)\B) = B v Bc = all)
+    // Note Ac\B = (A v B)c
+
+    // Offspring 2:
+    // A^B and Ac, remainder A\B unplanned
+    // (note A^B v Ac v A\B = (A^B v A\B) v Ac = A v Ac = all)
+
     auto startA = startIndices.first;
     auto startB = startIndices.second;
 
     // Sort routes according to center angle for both parents
-
-    auto const &routesA = _getNonEmptyRoutesSortedByAngleCenter(
-        data, parents.first->getRoutes());
-    auto const &routesB = _getNonEmptyRoutesSortedByAngleCenter(
-        data, parents.second->getRoutes());
+    auto const routesA
+        = getNonEmptyRoutesByAscendingAngle(data, parents.first->getRoutes());
+    auto const routesB
+        = getNonEmptyRoutesByAscendingAngle(data, parents.second->getRoutes());
 
     size_t nRoutesA = routesA.size();
     size_t nRoutesB = routesB.size();
@@ -93,9 +100,9 @@ Individual selectiveRouteExchange(
     ClientSet selectedA;
     ClientSet selectedB;
 
-    // Routes are sorted on polar angle by the local search/educate step, so
-    // selecting adjacent routes in both parents should result in a large
-    // overlap when the start indices are close to each other.
+    // Routes are sorted on polar angle, so selecting adjacent routes in both
+    // parents should result in a large overlap when the start indices are
+    // close to each other.
     for (size_t r = 0; r < numMovedRoutes; r++)
     {
         selectedA.insert(routesA[(startA + r) % nRoutesA].begin(),
@@ -195,21 +202,6 @@ Individual selectiveRouteExchange(
         if (!selectedA.contains(c))
             clientsInSelectedBNotA.insert(c);
 
-    // We create two candidate offsprings, both based on parent A:
-    // Let A and B denote the set of customers selected from parents A and B
-    // Ac and Bc denote the complements: the customers not selected
-    // Let v denote union and ^ intersection
-    // Parent A: A v Ac
-    // Parent B: B v Bc
-
-    // Offspring 1:
-    // B and Ac\B, remainder A\B unplanned
-    // (note B v (Ac\B) v (A\B) = B v ((Ac v A)\B) = B v Bc = all)
-    // Note Ac\B = (A v B)c
-
-    // Offspring 2:
-    // A^B and Ac, remainder A\B unplanned
-    // (note A^B v Ac v A\B = (A^B v A\B) v Ac = A v Ac = all)
     Routes routes1(data.numVehicles());
     Routes routes2(data.numVehicles());
 
@@ -236,9 +228,9 @@ Individual selectiveRouteExchange(
         for (Client c : routesA[indexA])
         {
             if (!clientsInSelectedBNotA.contains(c))
-                routes1[indexA].push_back(c);  // Ac\B
+                routes1[indexA].push_back(c);  // c in Ac\B
 
-            routes2[indexA].push_back(c);  // Ac
+            routes2[indexA].push_back(c);  // c in Ac
         }
     }
 

--- a/pyvrp/cpp/educate/LocalSearch.cpp
+++ b/pyvrp/cpp/educate/LocalSearch.cpp
@@ -252,20 +252,11 @@ void LocalSearch::loadIndividual(Individual const &individual)
 
 Individual LocalSearch::exportIndividual()
 {
-    std::vector<std::pair<double, int>> routePolarAngles;
-    routePolarAngles.reserve(data.numVehicles());
-
-    for (size_t r = 0; r < data.numVehicles(); r++)
-        routePolarAngles.emplace_back(routes[r].angleCenter, r);
-
-    // Empty routes have a large center angle, and thus always sort at the end
-    std::sort(routePolarAngles.begin(), routePolarAngles.end());
-
     std::vector<std::vector<int>> indivRoutes(data.numVehicles());
 
     for (size_t r = 0; r < data.numVehicles(); r++)
     {
-        Node *node = startDepots[routePolarAngles[r].second].next;
+        Node *node = startDepots[r].next;
 
         while (!node->isDepot())
         {

--- a/pyvrp/cpp/educate/Route.cpp
+++ b/pyvrp/cpp/educate/Route.cpp
@@ -24,7 +24,7 @@ void Route::setupNodes()
 
 void Route::setupSector()
 {
-    if (empty())  // Note: sector is undefined for empty routes
+    if (empty())  // Note: sector has no meaning for empty routes, don't use
         return;
 
     auto const depotData = data.client(0);

--- a/pyvrp/cpp/educate/Route.cpp
+++ b/pyvrp/cpp/educate/Route.cpp
@@ -24,11 +24,8 @@ void Route::setupNodes()
 
 void Route::setupSector()
 {
-    if (empty())
-    {
-        angleCenter = 1.e30;
+    if (empty())  // Note: sector is undefined for empty routes
         return;
-    }
 
     auto const depotData = data.client(0);
     auto const clientData = data.client(n(depot)->client);
@@ -38,16 +35,10 @@ void Route::setupSector()
 
     sector.initialize(angle);
 
-    int cumulatedX = 0;
-    int cumulatedY = 0;
-
     for (auto it = nodes.begin(); it != nodes.end() - 1; ++it)
     {
         auto const *node = *it;
         assert(!node->isDepot());
-
-        cumulatedX += data.client(node->client).x;
-        cumulatedY += data.client(node->client).y;
 
         auto const clientData = data.client(node->client);
         auto const angle = CircleSector::positive_mod(static_cast<int>(
@@ -57,14 +48,6 @@ void Route::setupSector()
 
         sector.extend(angle);
     }
-
-    // This computes a pseudo-angle that sorts roughly equivalently to the atan2
-    // angle, but is much faster to compute. See the following post for details:
-    // https://stackoverflow.com/a/16561333/4316405.
-    auto const routeSize = static_cast<double>(size());
-    auto const dy = cumulatedY / routeSize - data.depot().y;
-    auto const dx = cumulatedX / routeSize - data.depot().x;
-    angleCenter = std::copysign(1. - dx / (std::fabs(dx) + std::fabs(dy)), dy);
 }
 
 void Route::setupRouteTimeWindows()

--- a/pyvrp/cpp/educate/Route.h
+++ b/pyvrp/cpp/educate/Route.h
@@ -26,16 +26,15 @@ class Route
     // Populates the nodes vector.
     void setupNodes();
 
-    // Sets the angle and sector data.
+    // Sets the sector data.
     void setupSector();
 
     // Sets forward node time windows.
     void setupRouteTimeWindows();
 
-public:                  // TODO make fields private
-    int idx;             // Route index
-    Node *depot;         // Pointer to the associated depot
-    double angleCenter;  // Angle of the barycenter of the route
+public:           // TODO make fields private
+    int idx;      // Route index
+    Node *depot;  // Pointer to the associated depot
 
     /**
      * @return The client or depot node at the given position.

--- a/pyvrp/crossover/tests/test_selective_route_exchange.py
+++ b/pyvrp/crossover/tests/test_selective_route_exchange.py
@@ -154,8 +154,8 @@ def test_srex_a_right_move():
     indiv2 = Individual(data, [[3], [2], [4, 1]])
 
     # We describe the A-right case here in detail. The tests below for A-left,
-    # B-left and B-right can be worked out similarly: note that we only change
-    # the ordering of the routes.
+    # B-left and B-right can be worked out similarly. Note that the test cases
+    # are somewhat contrived since the input routes must be sorted by angle.
     #
     # Initial start indices (indicated by **) A\B = {1,3} \ {1, 4} = {3}, # = 1
     # [4] [2] *[1, 3]*

--- a/pyvrp/crossover/tests/test_selective_route_exchange.py
+++ b/pyvrp/crossover/tests/test_selective_route_exchange.py
@@ -71,6 +71,11 @@ def test_srex_move_all_routes():
 def test_srex_sorts_routes():
     """
     Tests if SREX sorts the input before applying the operator.
+
+    Internally, SREX first sorts the given routes by angle w.r.t. the depot.
+    Since that always results in the same route order for the same set of
+    routes, SREX should be invariant to route permutations and always produce
+    the exact same offspring.
     """
     data = read("data/OkSmall.txt")
     cost_evaluator = CostEvaluator(20, 6)

--- a/pyvrp/educate/tests/test_TwoOpt.py
+++ b/pyvrp/educate/tests/test_TwoOpt.py
@@ -31,8 +31,8 @@ def test_OkSmall_instance():
 
     # First improving (U, V) node pair is (1, 3), which results in the route
     # [1, 3, 2, 4]. The second improving node pair involves the depot of an
-    # empty route: (1, 0). This results in routes [3, 2, 4] and [1].
-    assert_equal(improved_individual.get_routes(), [[3, 2, 4], [1], []])
+    # empty route: (1, 0). This results in routes [1] and [3, 2, 4].
+    assert_equal(improved_individual.get_routes(), [[1], [3, 2, 4], []])
 
 
 @mark.parametrize("seed", [2643, 2742, 2941, 3457, 4299, 4497, 6178, 6434])


### PR DESCRIPTION
This PR:
* Moves sorting of routes for SREX into SREX itself
* Removes sorting of routes in LocalSearch::exportIndividual
* Adds some comments to help understanding the two offspring candidates created by SREX

- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.